### PR TITLE
Add option to set gul alloc rule in compose

### DIFF
--- a/compose/model.worker.yml
+++ b/compose/model.worker.yml
@@ -21,6 +21,7 @@ services:
      - OASIS_CELERY_DB_PORT=3306
      - OASIS_KEEP_RUN_DIR=True
      - OASIS_DEBUG_MODE=True
+     - OASIS_KTOOLS_ALLOC_RULE_GUL=${MULTI_PERIL:-0}
     volumes:
 #     - ./log:/var/log/oasis:rw
      - ${OASIS_MODEL_DATA_DIR:-./data/static}:${MODEL_MOUNT_TARGET:-/var/oasis}:rw


### PR DESCRIPTION
conf.ini will override any alloc rule set in oasislmf.json, the priority should be switched to oasislmf.json 

work around for the moment in CI testing  