### PR TITLE
Fix/mdk runner substring

### DIFF
--- a/docker/Dockerfile.worker-git
+++ b/docker/Dockerfile.worker-git
@@ -5,4 +5,5 @@ ARG BRANCH=develop
 RUN apt update && apt install -y git g++ build-essential libtool zlib1g-dev autoconf pkg-config
 
 RUN pip3 uninstall oasislmf -y
+RUN pip3 install --upgrade ods_tools
 RUN pip3 install -v git+https://git@github.com/OasisLMF/OasisLMF.git@${BRANCH:-develop}#egg=oasislmf

--- a/testscript/run_model.py
+++ b/testscript/run_model.py
@@ -193,7 +193,7 @@ def model_run_ok(model_run_dir, model_run_mode):
         else:
             substr, dir_name, dir_contents = os.path.basename(fp), os.path.dirname(fp), os.listdir(os.path.dirname(fp))
             try:
-                fn = [fn for fn in dir_contents if substr.lower() in fn.lower()][0]
+                fn = [fn for fn in dir_contents if substr in fn][0]
             except (AttributeError, IndexError):
                 print('False')
                 return False


### PR DESCRIPTION
## Fixes for piwind testing 
* Upgrade ods_tools to latest version on docker build 
* Fixed substring matching error when checking for RI output 